### PR TITLE
Update README.md

### DIFF
--- a/comps/embeddings/README.md
+++ b/comps/embeddings/README.md
@@ -83,7 +83,7 @@ docker run -d --name="embedding-tei-server" -p 6000:6000 --ipc=host -e http_prox
 
 ```bash
 cd docker
-docker compose -f docker_compose.yaml up -d
+docker compose -f docker_compose_embedding.yaml up -d
 ```
 
 # 🚀Consume Embedding Service


### PR DESCRIPTION
incorrect reference to compose file; Changed to "docker_compose_embedding.yaml"

## Description

Incorrect reference to docker compose file

## Issues
NA

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Dependencies

NA

## Tests

Tested on local machine; 
Python 3.9.6
Apple M3 Max / MacOS 14.1

